### PR TITLE
Link directly to dubber to avoid breaking https

### DIFF
--- a/index.md
+++ b/index.md
@@ -75,7 +75,7 @@ lives of underserved populations in low-income regions.
 
 <h2>Mailing List</h2>
 Please subscribe to our <a
-href="https://changemm.cs.washington.edu/mailman/listinfo/change">
+href="https://dubber.cs.washington.edu/mailman/listinfo/change">
 mailing list</a>. View archives at <a href="https://www.mail-archive.com/change@change.washington.edu/">mail-archive.com</a>
 
 <!--

--- a/participate.md
+++ b/participate.md
@@ -8,7 +8,7 @@ notitle: true
 <h2>Subscribe</h2>
 
 If you are interested in participating, please subscribe to our <a
-href="https://changemm.cs.washington.edu/mailman/listinfo/change">
+href="https://dubber.cs.washington.edu/mailman/listinfo/change">
 mailing list</a>.  It’s where the majority of our community
 participates and where you will see announcements for upcoming events.
 


### PR DESCRIPTION
The dubber webserver does not have a tls certificate for
changemm.cs.washington.edu. We could get them to add this URL to
their cert, but just linking to dubber is easier.